### PR TITLE
Add cm_item_list element type which supports render arrays as items

### DIFF
--- a/cm_tools.element.inc
+++ b/cm_tools.element.inc
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @file Render elements provided by CM Tools module.
+ */
+
+/**
+ * Implements hook_element_info().
+ */
+function cm_tools_element_info() {
+  $types = array();
+
+  /*
+   * Thin wrapper around #theme => 'item_list' which allows
+   * render arrays to be passed as '#items'.
+   */
+  $types['cm_item_list'] = array(
+    '#theme' => 'item_list',
+    '#items' => array(),
+    '#list_type' => 'ul',
+    '#attributes' => array(),
+    '#pre_render' => array('cm_tools_item_list_pre_render'),
+  );
+
+  return $types;
+}
+
+/**
+ * Pre-render callback for the item_list element.
+ *
+ * We detect whether render arrays being passed under '#items'
+ * and if so, render them into strings.
+ *
+ * @param $elements
+ * @return mixed
+ */
+function cm_tools_item_list_pre_render($elements) {
+
+  // Need to replace the #type since theme('item_list')
+  // expects to find 'ul' or 'ol' there, not 'cm_item_list'!
+  $elements['#type'] = $elements['#list_type'];
+
+  // Sadly a bit of magic is necessary here since '#items'
+  // can legitimately be an array.
+  foreach ($elements['#items'] as &$item) {
+
+    // An item can be it's contents directly, or the
+    // contents can be found in the 'data' property.
+    if (isset($item['data'])) {
+      $item = &$item['data'];
+    }
+
+    if (is_array($item) && !isset($item['children'])) {
+      $item = drupal_render($item);
+    }
+  }
+
+  return $elements;
+}

--- a/cm_tools.module
+++ b/cm_tools.module
@@ -10,6 +10,8 @@
  * every page request.
  */
 
+include_once 'cm_tools.element.inc';
+
 /**
  * Include .inc files as necessary.
  *


### PR DESCRIPTION
Sadly theme_item_list does not support render array elements as the values and must be passed them as strings.

This is sad for those of us who want to return render arrays allowing later peeps to come along and inspect / alter their output.

Solution! Define a new '#type' => 'cm_item_list' which simple calls through to theme('item_list') but not before a #pre_render callback renders all items which are determined to be render arrays.

Nice.
