### PR TITLE
Only enable blocks by default if a region is supplied.

### DIFF
--- a/includes/block.inc
+++ b/includes/block.inc
@@ -18,7 +18,7 @@ function cm_tools_block_position($module, $delta, $block = array(), $all_themes 
     'weight' => 0,
     'cache' => -1,
     // Only enable the block by default if a region is supplied.
-    'status' => !empty($block['region']),
+    'status' => (int) !empty($block['region']),
     'title' => '',
     'region' => '',
     'pages' => '',

--- a/includes/block.inc
+++ b/includes/block.inc
@@ -17,7 +17,8 @@ function cm_tools_block_position($module, $delta, $block = array(), $all_themes 
     'theme' => variable_get('theme_default', 'seven'),
     'weight' => 0,
     'cache' => -1,
-    'status' => 1,
+    // Only enable the block by default if a region is supplied.
+    'status' => !empty($block['region']),
     'title' => '',
     'region' => '',
     'pages' => '',


### PR DESCRIPTION
When enabling a new theme by default, any enabled blocks (i.e. with a non-empty status) in the previously-default theme will be set to appear in the new theme's default region if the block's region in the previously-default theme is not in the new theme.
When the region is an empty string (which it would be if it wasn't specified when placing a block with cm_tools_block_position() ), this means the block would always get placed into the new theme's default region (usually content). This is not intended behaviour.
So, instead, cm_tools_block_position() should only enable a block if a region is supplied. It would be up to the calling code to specify a valid region. 

A common example of this is using cm_tools_block_position() to just set the title of a block to '<none>', even when not setting a region (e.g. context module might be placing the block instead), so in this case, status should not be 1 when the region is not a valid region.
