### PR TITLE
Allow blocks to be marked as translatable with i18n_block.

### DIFF
--- a/includes/block.inc
+++ b/includes/block.inc
@@ -27,6 +27,7 @@ function cm_tools_block_position($module, $delta, $block = array(), $all_themes 
     $block += array(
       'i18n_mode' => 0,
     );
+    i18n_block_update_strings($block, $block['i18n_mode']);
   }
 
   // Set default keys for the db_merge query.

--- a/includes/block.inc
+++ b/includes/block.inc
@@ -23,6 +23,11 @@ function cm_tools_block_position($module, $delta, $block = array(), $all_themes 
     'region' => '',
     'pages' => '',
   );
+  if (module_exists('i18n_block')) {
+    $block += array(
+      'i18n_mode' => 0,
+    );
+  }
 
   // Set default keys for the db_merge query.
   $merge_keys = array(
@@ -48,6 +53,7 @@ function cm_tools_block_position($module, $delta, $block = array(), $all_themes 
       'theme'  => TRUE,
       'title'  => TRUE,
       'pages'  => TRUE,
+      'i18n_mode' => TRUE,
     )))
     ->updateFields(array_intersect_key($block, array(
       'cache'  => TRUE,
@@ -56,6 +62,7 @@ function cm_tools_block_position($module, $delta, $block = array(), $all_themes 
       'region' => TRUE,
       'title' => TRUE,
       'pages'  => TRUE,
+      'i18n_mode' => TRUE,
     )))
     ->execute();
 }


### PR DESCRIPTION
i18n_block just adds another field to the block table, so it's simple to just extend cm_tools_block_position() to mark blocks as translatable on positioning them.
