### PR TITLE
Add stable sort functions.

### DIFF
--- a/cm_tools.module
+++ b/cm_tools.module
@@ -315,7 +315,98 @@ function cm_tools_array_remove_values(&$haystack, $values) {
   }
 }
 
+/**
+ * Sort an array by values using a user-defined comparison function.
+ *
+ * However, unlike usort, equal values maintain their order.
+ *
+ * The comparison function must return an integer less than, equal to, or
+ * greater than zero if the first argument is considered to be
+ * respectively less than, equal to, or greater than the second.
+ *
+ * @param array $array The input array.
+ * @param callable $cmp_function
+ */
+function cm_tools_stable_usort(&$array, $cmp_function) {
+  // Arrays of size < 2 require no action.
+  if (count($array) < 2) return;
+  // Split the array in half
+  $halfway = count($array) / 2;
+  $array1 = array_slice($array, 0, $halfway);
+  $array2 = array_slice($array, $halfway);
+  // Recurse to sort the two halves
+  cm_tools_stable_usort($array1, $cmp_function);
+  cm_tools_stable_usort($array2, $cmp_function);
+  // If all of $array1 is <= all of $array2, just append them.
+  if (call_user_func($cmp_function, end($array1), $array2[0]) < 1) {
+    $array = array_merge($array1, $array2);
+    return;
+  }
+  // Merge the two sorted arrays into a single sorted array
+  $array = array();
+  $ptr1 = $ptr2 = 0;
+  while ($ptr1 < count($array1) && $ptr2 < count($array2)) {
+    if (call_user_func($cmp_function, $array1[$ptr1], $array2[$ptr2]) < 1) {
+      $array[] = $array1[$ptr1++];
+    }
+    else {
+      $array[] = $array2[$ptr2++];
+    }
+  }
+  // Merge the remainder
+  while ($ptr1 < count($array1)) $array[] = $array1[$ptr1++];
+  while ($ptr2 < count($array2)) $array[] = $array2[$ptr2++];
+  return;
+}
 
+/**
+ * Sort an array by user-defined comparison function, preserving indexes.
+ *
+ * However, unlike ussort, equal values maintain their order.
+ *
+ * The comparison function must return an integer less than, equal to, or
+ * greater than zero if the first argument is considered to be
+ * respectively less than, equal to, or greater than the second.
+ *
+ * @param array $array The input array.
+ * @param callable $cmp_function
+ */
+function cm_tools_stable_uasort(&$array, $cmp_function) {
+  if(count($array) < 2) {
+    return;
+  }
+  $halfway = count($array) / 2;
+  $array1 = array_slice($array, 0, $halfway, TRUE);
+  $array2 = array_slice($array, $halfway, NULL, TRUE);
+
+  cm_tools_stable_uasort($array1, $cmp_function);
+  cm_tools_stable_uasort($array2, $cmp_function);
+  if(call_user_func($cmp_function, end($array1), reset($array2)) < 1) {
+    $array = $array1 + $array2;
+    return;
+  }
+  $array = array();
+  reset($array1);
+  reset($array2);
+  while(current($array1) && current($array2)) {
+    if(call_user_func($cmp_function, current($array1), current($array2)) < 1) {
+      $array[key($array1)] = current($array1);
+      next($array1);
+    } else {
+      $array[key($array2)] = current($array2);
+      next($array2);
+    }
+  }
+  while(current($array1)) {
+    $array[key($array1)] = current($array1);
+    next($array1);
+  }
+  while(current($array2)) {
+    $array[key($array2)] = current($array2);
+    next($array2);
+  }
+  return;
+}
 
 /**
  * Implements hook_theme().


### PR DESCRIPTION
usort and uasort have undefined behaviour for values that are considered equal (the even items are likely to come out shuffled).

This commit provides stable sort versions of usort and uasort, for 'light touch' sorting. If all values are considered equal (as determined by your callback), the array you get back should match the one you put in.
