### PR TITLE
Add option to 'remove class cruft'

### DIFF
--- a/cm_tools.module
+++ b/cm_tools.module
@@ -421,6 +421,14 @@ function cm_tools_theme($existing, $type, $theme, $path) {
   return $items;
 }
 
+/**
+ * Implements hook_preprocess().
+ */
+function cm_tools_preprocess(&$variables, $hook) {
+  if (variable_get('cm_tools_decruft_classes', FALSE)) {
+    cm_tools_array_remove_values($variables['classes_array'], drupal_html_class($hook));
+  }
+}
 
 /**
  * Implements hook_preprocess_entity().
@@ -482,21 +490,35 @@ function cm_tools_preprocess_entity(&$vars, $hook, $suggestion_prefix = 'entity_
     if (!in_array($suggestion, $vars['theme_hook_suggestions']) && !in_array($suggestion_prefix . $suggestion, $vars['theme_hook_suggestions'])) {
       cm_tools_insert_theme_hook_suggestion($vars['theme_hook_suggestions'], "{$entity_type}__{$id}", $suggestion_prefix . $suggestion);
     }
-  }
 
-  // Add a class indicating view mode.
-  $classes = array();
-  $classes[] = drupal_clean_css_identifier("{$entity_type}-{$view_mode}");
-  // Also add entity-bundle-view_mode combo
-  $classes[] = drupal_clean_css_identifier("{$entity_type}-{$bundle}-{$view_mode}");
-  if (isset($vars['classes_array'])) {
-    $vars['classes_array'] = array_merge($vars['classes_array'], $classes);
-  }
-  elseif (isset($vars['attributes_array'])) {
-    $vars['attributes_array'] = array_merge_recursive($vars['attributes_array'], array('class' => $classes));
-  }
-  elseif (isset($vars['classes']) && is_string($vars['classes'])) {
-    $vars['classes'] .= ' ' . implode(' ', $classes);
+    // We either supplement the default classes, or strip them. If you're going
+    // to do it at all, may as well go all out.
+    $classes = array();
+    // If we're stripping…
+    if (variable_get('cm_tools_decruft_classes', FALSE)) {
+      // Ditch some standard entity ones.
+      cm_tools_array_remove_values($vars['classes_array'], array(
+        drupal_html_class('entity-' . $entity_type),
+        drupal_html_class($entity_type . '-' . $bundle),
+      ));
+    }
+    // Else we'll supplement…
+    else {
+      // Add a class indicating view mode.
+      $classes[] = drupal_clean_css_identifier("{$entity_type}-{$view_mode}");
+      // Also add entity-bundle-view_mode combo
+      $classes[] = drupal_clean_css_identifier("{$entity_type}-{$bundle}-{$view_mode}");
+    }
+
+    if (isset($vars['classes_array'])) {
+      $vars['classes_array'] = array_merge($vars['classes_array'], $classes);
+    }
+    elseif (isset($vars['attributes_array'])) {
+      $vars['attributes_array'] = array_merge_recursive($vars['attributes_array'], array('class' => $classes));
+    }
+    elseif (isset($vars['classes']) && is_string($vars['classes'])) {
+      $vars['classes'] .= ' ' . implode(' ', $classes);
+    }
   }
 }
 
@@ -516,6 +538,14 @@ function cm_tools_preprocess_comment(&$vars, $hook) {
  */
 function cm_tools_preprocess_node(&$vars, $hook) {
   $vars['entity_type'] = 'node';
+  if (variable_get('cm_tools_decruft_classes', FALSE)) {
+    cm_tools_array_remove_values($vars['classes_array'], array(
+      'node-promoted',
+      'node-sticky',
+      'node-teaser',
+      'node-preview',
+    ));
+  }
   cm_tools_preprocess_entity($vars, $hook, '');
 }
 
@@ -525,6 +555,11 @@ function cm_tools_preprocess_node(&$vars, $hook) {
 function cm_tools_preprocess_taxonomy_term(&$vars, $hook) {
   $vars['entity_type'] = 'taxonomy_term';
   $vars[$vars['entity_type']] = $vars['term'];
+  if (variable_get('cm_tools_decruft_classes', FALSE)) {
+    cm_tools_array_remove_values($vars['classes_array'], array(
+      'vocabulary-' . str_replace('_', '-', $vars['term']->vocabulary_machine_name),
+    ));
+  }
   cm_tools_preprocess_entity($vars, $hook, '');
 }
 


### PR DESCRIPTION
Generally, the nicer the CSS, the less 'standard' css classes we'll use. So ideally we'll like to be able to remove all those default classes from things. D8 goes a long way toward this (choose the classy base theme if you want the classes) but in D7 we're kind of on our own.

So we normally would remove them in a preprocess. Oftentimes that means we end up with something like this:

```php
$variables['classes_array'] = array();
```

… before then adding just the nice custom classes we want. Whilst this is tempting because it's quick and easy to get a 'clean slate', it's a pretty nuclear solution, and totally breaks certain things (such as contextual links regions).

A nicer way would be to methodically remove all the uber-generic crufty classes we don't want eg. for paragraphs:

```php
  cm_tools_array_remove_values($variables['classes_array'], array(
    'entity',
    'entity-paragraphs-item',
    'paragraphs-item-' . drupal_clean_css_identifier($variables['elements']['#entity']->bundle),
    'paragraphs-item-' . $variables['view_mode'],
    'paragraphs-item-' . drupal_clean_css_identifier($variables['elements']['#entity']->bundle) . '-' . $variables['view_mode'],
  ));
```

… but as you can see that's a long way from quick and easy.

So, the suggestion is we have a global opt-in setting for cm_tools that just does this for common theme hooks (preprocesses away the stock classes). We'll need to module_implements_alter each of our preprocess functions to be late (specifically, later than whatever module defines the hook).