### PR TITLE
Issue #32: Add a site monitoring page.

### DIFF
--- a/cm_tools.install
+++ b/cm_tools.install
@@ -15,7 +15,7 @@ function cm_tools_requirements($phase) {
     $checks['cm_tools'] = array(
       'title' => t('CM Tools - Monitoring'),
       'value' => t('Monitoring page available at <a href="@monitoring_url">@monitoring_url</a>', array(
-        '@monitoring_url' => url('cm_tools/monitoring/' . cm_tools_get_uptime_path_token(), array('absolute' => TRUE,)),
+        '@monitoring_url' => url('cm_tools/monitoring/' . cm_tools_get_uptime_path_token(), array('absolute' => TRUE)),
       )),
       'description' => t('You may use this page to check the up/down status of the site using external tools like uptimerobot, NewRelic or StatusCake. The URL is stable, and the contents contains a stable element and the current server date and time.'),
     );

--- a/cm_tools.install
+++ b/cm_tools.install
@@ -1,6 +1,7 @@
 <?php
 
 /**
+ * @file
  * Install related functionality for CM Tools.
  */
 
@@ -13,7 +14,9 @@ function cm_tools_requirements($phase) {
 
     $checks['cm_tools'] = array(
       'title' => t('CM Tools - Monitoring'),
-      'value' => t('Monitoring page available at <a href="@monitoring_url">@monitoring_url</a>', array('@monitoring_url' => url('cm_tools/monitoring/' . cm_tools_get_uptime_path_token(), array('absolute' => TRUE,)))),
+      'value' => t('Monitoring page available at <a href="@monitoring_url">@monitoring_url</a>', array(
+        '@monitoring_url' => url('cm_tools/monitoring/' . cm_tools_get_uptime_path_token(), array('absolute' => TRUE,)),
+      )),
       'description' => t('You may use this page to check the up/down status of the site using external tools like uptimerobot, NewRelic or StatusCake. The URL is stable, and the contents contains a stable element and the current server date and time.'),
     );
   }

--- a/cm_tools.install
+++ b/cm_tools.install
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Install related functionality for CM Tools.
+ */
+
+/**
+ * Implements hook_requirements().
+ */
+function cm_tools_requirements($phase) {
+  $checks = array();
+  if ($phase == 'runtime') {
+
+    $checks['cm_tools'] = array(
+      'title' => t('CM Tools - Monitoring'),
+      'value' => t('Monitoring page available at <a href="@monitoring_url">@monitoring_url</a>', array('@monitoring_url' => url('cm_tools/monitoring/' . cm_tools_get_uptime_path_token(), array('absolute' => TRUE,)))),
+      'description' => t('You may use this page to check the up/down status of the site using external tools like uptimerobot, NewRelic or StatusCake. The URL is stable, and the contents contains a stable element and the current server date and time.'),
+    );
+  }
+
+  return $checks;
+}

--- a/cm_tools.module
+++ b/cm_tools.module
@@ -90,7 +90,7 @@ function cm_tools_init() {
 /**
  * Access callback for the CM Tools monitoring page.
  *
- * @param $token
+ * @param string $token
  *   The token to check.
  *
  * @return bool

--- a/cm_tools.module
+++ b/cm_tools.module
@@ -52,6 +52,72 @@ function cm_tools_form_include(&$form_state, $file, $module = 'cm_tools', $dir =
 }
 
 /**
+ * Implements hook_menu().
+ */
+function cm_tools_menu() {
+  $items['cm_tools/monitoring/%'] = array(
+    'page callback' => 'cm_tools_monitoring_page_callback',
+    'access callback' => 'cm_tools_monitoring_access_callback',
+    'access arguments' => array(2),
+  );
+
+  return $items;
+}
+
+/**
+ * Implements hook_init().
+ */
+function cm_tools_init() {
+  // Our monitoring page is never in maintenance mode.
+  if ($_GET['q'] === 'cm_tools/monitoring/' . cm_tools_get_uptime_path_token()) {
+    $GLOBALS['conf']['maintenance_mode'] = 0;
+  }
+}
+
+/**
+ * Access callback for the CM Tools monitoring page.
+ *
+ * @param $token
+ *   The token to check.
+ *
+ * @return bool
+ *   TRUE if the token matches the one stored for this site. FALSE otherwise.
+ */
+function cm_tools_monitoring_access_callback($token) {
+  return $token === cm_tools_get_uptime_path_token();
+}
+
+/**
+ * Page callback for the monitoring page.
+ */
+function cm_tools_monitoring_page_callback() {
+  // @TODO: We could check to see if Memcache etc. are configured and functioning correctly.
+  drupal_page_is_cacheable(FALSE);
+  // Print something unlikely to be printed by e.g. Apache error pages.
+  print sha1(__FUNCTION__ . cm_tools_get_uptime_path_token());
+  print "\n";
+  print date('c');
+  drupal_exit();
+}
+
+/**
+ * Get a stable token for use in a path that is unique to this site.
+ *
+ * @return string
+ *   The path token.
+ */
+function cm_tools_get_uptime_path_token() {
+  if ($token = variable_get('cm_tools_get_uptime_path_token')) {
+    return $token;
+  }
+  else {
+    $token = drupal_random_key(64);
+    variable_set('cm_tools_get_uptime_path_token', $token);
+    return $token;
+  }
+}
+
+/**
  * Inserts one or more suggestions into a theme_hook_suggestions array.
  *
  * @param $haystack


### PR DESCRIPTION
Here's my quick first stab at adding a status page that will satisfy my requirements from #32 which were:

> It would be useful to have a URL on a site that:
> 
> * Is never cached
> * Does some simple checks and responds with a unique string and 200 status code
> * has a stable, but unique URL
> 
> This would support adding status checks that don't get cached by Cloudfront etc.

I've popped the URL on the admin/reports/status page for easy finding, and I reckon that if we need to change the token in the URL we can assume that the users of our module know how to do:

    variable_del('cm_tools_get_uptime_path_token');

What do you think?