### PR TITLE
Fix ArgumentCountError

### DIFF
--- a/includes/profile.inc
+++ b/includes/profile.inc
@@ -176,9 +176,7 @@ function cm_tools_update_efq_walk(array &$sandbox, EntityFieldQuery $query, call
  *   The entity type to iterate over.
  * @param callable $callback
  *   The callback to apply to each entity returned from the $query. The callback
- *   is called with two arguments:
- *   - The entity type of the entity in the second argument
- *   - The loaded entity.
+ *   is called with a single argument, which is the loaded entity.
  * @param null|string $bundle
  *   The bundle to iterate over, if NULL then all bundles of the given entity
  *   type will be iterated.


### PR DESCRIPTION
Using `cm_tools_update_entity_walk()` directly runs into an ArgumentCountError, because the entity type parameter that the documentation implies is needed for the `$callback` is ignored and only one argument is actually passed when invoking it with `call_user_func()`. Easy fix - update the documentation.